### PR TITLE
removed council fromd deposits area and added revenue breakdowns to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+# Revenue calculations
+
+For the purposes of assisting with data efforts.
+
+**1. Income**: From the fees taken from each transaction.
+
+- HTS:
+    - all HTS related transactions (crypto create, transfer etc) based on user filters and time range
+    - a question is how are HTS transfer fees calculated when done within a contract? here's an example: https://hashscan.io/mainnet/transaction/1723150013.221642009
+- HSCS: 
+    - all smart contract related service transactions (create, update etc) based on user filters and time range
+- HCS:
+    - all HCS related transactions (topic create, update, submit etc) based on user filters and time range
+- Other:
+    - all other transactions (not included above) based on user filters and time range
+
+**2. Deposits**: this area is a summary of all fees taken from transactions that are fed into the network
+
+- Nodes:
+    - this is the fee portion from every transaction that is sent to the consensus node: https://hashscan.io/mainnet/nodes
+- Staking:
+    - this is the portion of each transaction fee sent to account 0.0.800
+- Treasury:
+    - the portion sent to 0.0.98
+
+**3. Additional paramiters:**
+- Time period selection: 1hr, 24hrs, week, month, quarter, year, all time
+- Entity filters: the user can enter up to X entities to filter
+
+**Note:** "Concil" was removed as these could add to much complexity
+
+
 # Managing the repository
 
 *Notes by Brandon*

--- a/src/main.html
+++ b/src/main.html
@@ -77,14 +77,14 @@
                       <div class="cell">30%</div>
                       <div class="cell">178,032 ℏ</div>
                     </div>
-                    <div class="row">
+                    <!--<div class="row">
                       <div class="cell">Council</div>
                       <div class="cell">12%</div>
                       <div class="cell">98,551 ℏ</div>
-                    </div>
+                    </div>-->
                     <div class="row">
                       <div class="cell">Treasury</div>
-                      <div class="cell">8%</div>
+                      <div class="cell">20%</div>
                       <div class="cell">23,540 ℏ</div>
                     </div>
                   </div>


### PR DESCRIPTION
i removed "council" from under the deposits area, would have added a bunch of complexity but we can add it later

i also updated the readme with more details regarding how we should calculate revenue etc (i have notated a screenshot on our Miro board).

this should provide more clarity