### PR TITLE
enhanced privacy for analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,12 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-DFJB14V7Y3');
+  gtag('config', 'G-DFJB14V7Y3', {
+    'anonymize_ip': true,
+    'allow_ad_personalization_signals': false,
+    'allow_google_signals': false,
+    'send_page_view': true
+  });
 </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
added this to the config for GA4

`gtag('config', 'G-XXXXXXXXXX', {
    'anonymize_ip': true,  // Anonymize IP addresses
    'allow_ad_personalization_signals': false,  // Disable ad personalization
    'allow_google_signals': false,  // Disable Google Signals data collection
    'send_page_view': true  // Send page views by default
  });`